### PR TITLE
Fix single level column handling in parse_features

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ rf.fit(X, y)
 trees = [parse_tree(estimator.tree_, mapper=mapper) for estimator in rf.estimators_]
 
 model = Model(trees, mapper)
+model.build()
+
+model.set_majority_class(m_class=1)
 
 objective = gp.LinExpr()
 
@@ -50,10 +53,9 @@ for feature in model.features.values():
     else:
         objective += feature.x
 
-model.set_objective(objective)
+model.setObjective(objective)
 
 model.optimize()
 
 print(model.solution)
-
 ```

--- a/ocean/feature/mapper.py
+++ b/ocean/feature/mapper.py
@@ -6,21 +6,38 @@ from .feature import Feature
 
 
 class FeatureMapper(Mapping[Hashable, Feature]):
-    _columns: pd.MultiIndex
+    _columns: pd.Index
     _map: dict[Hashable, Feature]
+
+    _codes: tuple[Hashable, ...] | None = None
+    _names: tuple[Hashable, ...]
 
     def __init__(
         self,
         names: Iterable[Hashable],
         features: Iterable[Feature],
-        columns: pd.MultiIndex,
+        columns: pd.Index,
     ) -> None:
         self._columns = columns
         self._map = dict(zip(names, features, strict=True))
+        self._names = tuple(columns.get_level_values(0))
 
     @property
-    def columns(self) -> list[tuple[Hashable, Hashable]]:
-        return self._columns.to_list()
+    def columns(self) -> pd.Index:
+        return self._columns
+
+    @property
+    def names(self) -> tuple[Hashable, ...]:
+        return self._names
+
+    @property
+    def codes(self) -> tuple[Hashable, ...]:
+        if self._codes is None:
+            if self._columns.nlevels == 1:
+                msg = "No one-hot encoded features found"
+                raise ValueError(msg)
+            self._codes = tuple(self._columns.get_level_values(1))
+        return self._codes
 
     def __len__(self) -> int:
         return len(self._map)

--- a/ocean/feature/parse.py
+++ b/ocean/feature/parse.py
@@ -2,7 +2,6 @@ from collections.abc import Hashable
 from typing import Any
 
 import pandas as pd
-import pandera.typing as pat
 
 from .feature import Feature
 from .mapper import FeatureMapper
@@ -10,7 +9,7 @@ from .mapper import FeatureMapper
 N_BINARY: int = 2
 
 
-def _count_unique(series: pat.Series[Any]) -> int:
+def _count_unique(series: pd.Series) -> int:
     return series.nunique()
 
 
@@ -27,7 +26,6 @@ def _parse(
     *,
     discretes: tuple[Hashable, ...] = (),
     scale: bool = True,
-    none_column: str = "",
 ) -> tuple[FeatureMapper, pd.DataFrame]:
     discrete = set(discretes)
     frames: list[Any] = []
@@ -35,7 +33,7 @@ def _parse(
     names: list[Hashable] = []
 
     for column in data.columns:
-        series = data[column].astype(object).rename(none_column)
+        series = data[column].astype(object).rename("")
         levels: tuple[float, ...] = ()
         codes: tuple[Hashable, ...] = ()
 
@@ -47,7 +45,7 @@ def _parse(
             frames.append(
                 pd.get_dummies(series, drop_first=True)
                 .iloc[:, 0]
-                .rename(none_column)
+                .rename("")
                 .astype(int)
             )
             ftype = Feature.Type.BINARY
@@ -68,7 +66,7 @@ def _parse(
         features.append(Feature(ftype=ftype, levels=levels, codes=codes))
 
     preprocessed = pd.concat(frames, axis=1, keys=names)
-    columns = pd.MultiIndex.from_tuples(preprocessed.columns)
+    columns = preprocessed.columns
     mapper = FeatureMapper(names=names, features=features, columns=columns)
     return mapper, preprocessed
 

--- a/ocean/tree/parse.py
+++ b/ocean/tree/parse.py
@@ -15,18 +15,19 @@ def _build_node(
     mapper: FeatureMapper,
 ) -> Node:
     idx = int(protocol.feature[node_id])
-    name, code = mapper.columns[idx]
-    code = code or None
+    name = mapper.names[idx]
     left_id, right_id = (
         int(protocol.left[node_id]),
         int(protocol.right[node_id]),
     )
+    threshold, code = None, None
     if mapper[name].is_numeric:
         threshold = float(protocol.threshold[node_id])
         if mapper[name].is_continuous:
             mapper[name].add(threshold)
-    else:
-        threshold = None
+    elif mapper[name].is_one_hot_encoded:
+        code = mapper.codes[idx]
+
     node = Node(node_id, feature=name, threshold=threshold, code=code)
     node.left = _parse_node(protocol, left_id, mapper=mapper)
     node.right = _parse_node(protocol, right_id, mapper=mapper)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
     "scikit-learn",
     "pandas",
     "anytree",
-    "pandera",
 ]
 
 optional-dependencies.dev = [

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,5 +1,5 @@
 {
-    "typeCheckingMode": "strict",
+    "typeCheckingMode": "standard",
     "reportMissingTypeStubs": "none",
     "reportUnknownMemberType": "none",
     "ignore": ["sklearn", "anytree"]


### PR DESCRIPTION
Adjust the handling of single-level columns in the `FeatureMapper` and related functions to improve feature parsing and mapping. Update the column type from `pd.MultiIndex` to `pd.Index` and ensure proper feature extraction without unnecessary renaming. Remove the dependency on `pandera` and modify type checking settings accordingly.