### PR TITLE
Refactor type annotations for clarity and strict checking

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,5 +1,5 @@
 {
-    "typeCheckingMode": "standard",
+    "typeCheckingMode": "strict",
     "reportMissingTypeStubs": "none",
     "reportUnknownMemberType": "none",
     "ignore": ["sklearn", "anytree"]


### PR DESCRIPTION
Improve type annotations in the FeatureMapper and parsing functions to enhance clarity and enforce strict type checking. Adjust type checking mode to strict in the configuration.