### PR TITLE
Remove unnecessary reassignment in clear_majority_class method

### DIFF
--- a/ocean/model/model.py
+++ b/ocean/model/model.py
@@ -112,7 +112,6 @@ class Model(BaseModel):
     def clear_majority_class(self) -> None:
         self.remove(self._scores)
         self._scores.clear()
-        self._scores = gp.tupledict()
 
     def _set_trees(
         self,


### PR DESCRIPTION
Eliminate redundant reassignment of the _scores variable in the clear_majority_class method to streamline the code.