### PR TITLE
Export MIPExplainer in module exports

### DIFF
--- a/ocean/__init__.py
+++ b/ocean/__init__.py
@@ -1,3 +1,4 @@
 from . import ensemble, feature, mip, tree
+from .ocean import MIPExplainer
 
-__all__ = ["ensemble", "feature", "mip", "tree"]
+__all__ = ["MIPExplainer", "ensemble", "feature", "mip", "tree"]


### PR DESCRIPTION
Include MIPExplainer in the module exports to make it accessible for external use.