### PR TITLE
Update floating-point comparisons and simplify variable handling

### DIFF
--- a/ocean/mip/variable/feature.py
+++ b/ocean/mip/variable/feature.py
@@ -66,15 +66,11 @@ class FeatureVar(Var, FeatureKeeper):
         return self._add_numeric(model, name)
 
     def _add_mu(self, model: BaseModel) -> gp.MVar:
-        mut = gp.GRB.BINARY if self.is_discrete else gp.GRB.CONTINUOUS
+        vtype = gp.GRB.CONTINUOUS if self.is_continuous else gp.GRB.BINARY
         n = len(self.levels) - 1
         name = f"{self._name}_mu"
-
-        if self.is_discrete:
-            mu = model.addMVar(shape=n, vtype=mut, name=name)
-        else:
-            lb, ub = 0.0, 1.0
-            mu = model.addMVar(shape=n, vtype=mut, lb=lb, ub=ub, name=name)
+        lb, ub = 0.0, 1.0
+        mu = model.addMVar(shape=n, vtype=vtype, lb=lb, ub=ub, name=name)
 
         for j in range(n - 1):
             model.addConstr(mu[j + 1] <= mu[j])

--- a/tests/feature/test_variable.py
+++ b/tests/feature/test_variable.py
@@ -55,32 +55,32 @@ def test_discrete() -> None:
     objective = (var.x - 1.0) ** 2
     model.setObjective(objective)
     model.optimize()
-    assert var.X == 1.0
+    assert np.isclose(var.X, 1.0)
 
     objective = (var.x - 2.0) ** 2
     model.setObjective(objective)
     model.optimize()
-    assert var.X == 2.0
+    assert np.isclose(var.X, 2.0)
 
     objective = (var.x - 3.0) ** 2
     model.setObjective(objective)
     model.optimize()
-    assert var.X == 3.0
+    assert np.isclose(var.X, 3.0)
 
     objective = (var.x - 0.9) ** 2
     model.setObjective(objective)
     model.optimize()
-    assert var.X == 1.0
+    assert np.isclose(var.X, 1.0)
 
     objective = (var.x - 2.7) ** 2
     model.setObjective(objective)
     model.optimize()
-    assert var.X == 3.0
+    assert np.isclose(var.X, 3.0)
 
     objective = (var.x - 1.8) ** 2
     model.setObjective(objective)
     model.optimize()
-    assert var.X == 2.0
+    assert np.isclose(var.X, 2.0)
     assert var.mget(0).X == 1.0
     assert var.mget(1).X == 0.0
 
@@ -118,7 +118,7 @@ def test_continuous() -> None:
     model.setObjective(objective)
     model.optimize()
     assert np.isclose(var.X, 1.5)
-    assert var.mget(0).X >= var.mget(0).X >= var.mget(0).X
+    assert var.mget(0).X >= var.mget(1).X >= var.mget(2).X
 
     objective = (var.x - 2.30) ** 2
     model.setObjective(objective)


### PR DESCRIPTION
Improve floating-point comparison accuracy in tests by using `np.isclose` and refactor the `_add_mu` method to streamline variable type handling for continuous and discrete cases.