### PR TITLE
Exclude dataset files from test coverage and correct shape list creation in tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,6 +7,7 @@ show_missing = True
 omit =
     *tests/*
     ocean/**/keeper.py
+    ocean/datasets/**/*.py
 exclude_lines =
     pragma: no cover
     raise NotImplementedError

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -225,9 +225,9 @@ class TestModelInitWeightsNoIsolation:
         )
         trees = tuple(parse_trees(clf, mapper=mapper))
         generator = np.random.default_rng(seed)
-        shapes = (generator.integers(n_estimators + 1, 2 * n_estimators + 1),)
+        shapes = [generator.integers(n_estimators + 1, 2 * n_estimators + 1)]
         if n_estimators > 2:
-            shapes += (generator.integers(1, n_estimators - 1),)
+            shapes += [generator.integers(1, n_estimators - 1)]
         for shape in shapes:
             weights = generator.random(shape).flatten()
             msg = r"The number of weights must match the number of trees."


### PR DESCRIPTION
Exclude dataset files from test coverage in the configuration and update tests to use lists instead of tuples for shape creation.