### PR TITLE
Change column initialization to Index in Mapper class

### DIFF
--- a/ocean/abc/mapper.py
+++ b/ocean/abc/mapper.py
@@ -94,7 +94,7 @@ class Mapper[T](Mapping[Key, T]):
         if isinstance(mapping, Mapper):
             columns = mapping.columns
         elif columns is None:
-            columns = pd.MultiIndex([])
+            columns = pd.Index([])
 
         return mapping, columns
 


### PR DESCRIPTION
Replace MultiIndex with Index for column initialization in the Mapper class to simplify the structure.