### PR TITLE
Refactor and rename MIPExplainer for clarity and consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ import numpy as np
 from sklearn.ensemble import RandomForestClassifier
 
 from ocean.datasets import load_adult
-from ocean.explainer import MIPExplainer
+from ocean.explainer import MixedIntegerProgramExplainer
 
 # Load the adult dataset
 (data, target), mapper = load_adult()
@@ -39,7 +39,7 @@ rf.fit(data, target)
 y = int(rf.predict(x).item())
 
 # Explain the prediction using MIPEXplainer
-model = MIPExplainer(rf, mapper=mapper)
+model = MixedIntegerProgramExplainer(rf, mapper=mapper)
 x = x.flatten()
 explanation = model.explain(x, y=1 - y, norm=1)
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ from ocean.datasets import load_adult
 from ocean.explainer import MIPExplainer
 
 # Load the adult dataset
-mapper, (data, target) = load_adult()
+(data, target), mapper = load_adult()
 
 # Generate a random instance from the dataset.
 generator = np.random.default_rng(42)

--- a/README.md
+++ b/README.md
@@ -27,23 +27,22 @@ from ocean.explainer import MIPExplainer
 # Load the adult dataset
 mapper, (data, target) = load_adult()
 
-# Generate a random instance
+# Generate a random instance from the dataset.
 generator = np.random.default_rng(42)
-i = generator.integers(0, data.shape[0])
-x = data.iloc[[i]]
+x = generator.choice(data, size=1)
 
 # Train a random forest classifier
 rf = RandomForestClassifier(n_estimators=10, max_depth=3, random_state=42)
 rf.fit(data, target)
 
 # Predict the class of the random instance
-y = int(rf.predict(x)[0])
+y = int(rf.predict(x).item())
 
 # Explain the prediction using MIPEXplainer
 model = MIPExplainer(rf, mapper=mapper)
-model.set_majority_class(m_class=1 - y)
-model.optimize()
+x = x.flatten()
+explanation = model.explain(x, y=1 - y, norm=1)
 
 # Show the explanation
-print(model.solution)
+print(explanation)
 ```

--- a/examples/random_forest.py
+++ b/examples/random_forest.py
@@ -9,7 +9,7 @@ from rich.progress import track
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import train_test_split
 
-from ocean import MIPExplainer
+from ocean import MixedIntegerProgramExplainer
 from ocean.datasets import load_adult, load_compas, load_credit
 
 if TYPE_CHECKING:
@@ -100,7 +100,7 @@ def main() -> None:  # noqa: PLR0914
     env.setParam("Seed", args.seed)
     env.start()
     start = time.time()
-    mip = MIPExplainer(rf, mapper=mapper, env=env)
+    mip = MixedIntegerProgramExplainer(rf, mapper=mapper, env=env)
     end = time.time()
     print("MIPExplainer built")
     print(f"Building the model took {end - start:.2f} seconds")

--- a/examples/random_forest.py
+++ b/examples/random_forest.py
@@ -73,12 +73,12 @@ def main() -> None:  # noqa: PLR0914
 
     # Load the data
     print("Loading the data")
-    mapper, (X, y) = load(args.dataset)
+    (X, y), mapper = load(args.dataset)
     print("Data loaded")
 
     X_train, X_test, y_train, _ = train_test_split(
-        X.to_numpy(),
-        y.to_numpy().flatten(),
+        X,
+        y,
         test_size=0.2,
         random_state=args.seed,
     )
@@ -107,16 +107,12 @@ def main() -> None:  # noqa: PLR0914
 
     # Generate multiple queries:
     queries: list[tuple[Array1D, int]] = []
-
+    X_test = pd.DataFrame(X_test)
     y_pred = rf.predict(X_test)
 
     print("Generating queries")
-    for x, y_ in zip(
-        X_test[: min(args.n_examples, len(X_test))],
-        y_pred[: min(args.n_examples, len(X_test))],
-        strict=True,
-    ):
-        queries.append((x, 1 - y_))
+    for i in range(min(args.n_examples, len(X_test))):
+        queries.append((X_test.iloc[i].to_numpy().flatten(), 1 - y_pred[i]))  # noqa: PERF401
     print("Queries generated")
 
     print("Running queries")

--- a/examples/readme.py
+++ b/examples/readme.py
@@ -7,22 +7,21 @@ from ocean.explainer import MIPExplainer
 # Load the adult dataset
 mapper, (data, target) = load_adult()
 
-# Generate a random instance
+# Generate a random instance from the dataset.
 generator = np.random.default_rng(42)
-i = generator.integers(0, data.shape[0])
-x = data.iloc[[i]]
+x = generator.choice(data, size=1)
 
 # Train a random forest classifier
 rf = RandomForestClassifier(n_estimators=10, max_depth=3, random_state=42)
 rf.fit(data, target)
 
 # Predict the class of the random instance
-y = int(rf.predict(x)[0])
+y = int(rf.predict(x).item())
 
 # Explain the prediction using MIPEXplainer
 model = MIPExplainer(rf, mapper=mapper)
-model.set_majority_class(m_class=1 - y)
-model.optimize()
+x = x.flatten()
+explanation = model.explain(x, y=1 - y, norm=1)
 
 # Show the explanation
-print(model.solution)
+print(explanation)

--- a/examples/readme.py
+++ b/examples/readme.py
@@ -2,7 +2,7 @@ import numpy as np
 from sklearn.ensemble import RandomForestClassifier
 
 from ocean.datasets import load_adult
-from ocean.explainer import MIPExplainer
+from ocean.explainer import MixedIntegerProgramExplainer
 
 # Load the adult dataset
 (data, target), mapper = load_adult()
@@ -19,7 +19,7 @@ rf.fit(data, target)
 y = int(rf.predict(x).item())
 
 # Explain the prediction using MIPEXplainer
-model = MIPExplainer(rf, mapper=mapper)
+model = MixedIntegerProgramExplainer(rf, mapper=mapper)
 x = x.flatten()
 explanation = model.explain(x, y=1 - y, norm=1)
 

--- a/examples/readme.py
+++ b/examples/readme.py
@@ -5,7 +5,7 @@ from ocean.datasets import load_adult
 from ocean.explainer import MIPExplainer
 
 # Load the adult dataset
-mapper, (data, target) = load_adult()
+(data, target), mapper = load_adult()
 
 # Generate a random instance from the dataset.
 generator = np.random.default_rng(42)

--- a/ocean/__init__.py
+++ b/ocean/__init__.py
@@ -1,4 +1,11 @@
 from . import datasets, ensemble, feature, mip, tree
-from .explainer import MIPExplainer
+from .explainer import MixedIntegerProgramExplainer
 
-__all__ = ["MIPExplainer", "datasets", "ensemble", "feature", "mip", "tree"]
+__all__ = [
+    "MixedIntegerProgramExplainer",
+    "datasets",
+    "ensemble",
+    "feature",
+    "mip",
+    "tree",
+]

--- a/ocean/datasets/__init__.py
+++ b/ocean/datasets/__init__.py
@@ -1,16 +1,13 @@
-from .load import Loaded, Loader
+from functools import partial
+
+from .load import Loader
+
+loader = Loader()
 
 
-def load_credit() -> Loaded:
-    return Loader("Credit").load()
-
-
-def load_adult() -> Loaded:
-    return Loader("Adult").load()
-
-
-def load_compas() -> Loaded:
-    return Loader("COMPAS").load()
+load_credit = partial(loader.load, name="Credit")
+load_adult = partial(loader.load, name="Adult")
+load_compas = partial(loader.load, name="COMPAS")
 
 
 __all__ = ["load_adult", "load_compas", "load_credit"]

--- a/ocean/explainer/__init__.py
+++ b/ocean/explainer/__init__.py
@@ -1,3 +1,3 @@
-from .mip import MIPExplainer
+from .mip import MixedIntegerProgramExplainer
 
-__all__ = ["MIPExplainer"]
+__all__ = ["MixedIntegerProgramExplainer"]

--- a/ocean/explainer/mip.py
+++ b/ocean/explainer/mip.py
@@ -11,7 +11,7 @@ from ..mip import Model, Solution, TreeVar
 from ..typing import Array1D, NonNegativeInt, PositiveInt
 
 
-class MIPExplainer(Model):
+class MixedIntegerProgramExplainer(Model):
     _garbage: list[gp.Var | gp.MVar | gp.Constr | gp.MConstr]
 
     def __init__(

--- a/ocean/explainer/mip.py
+++ b/ocean/explainer/mip.py
@@ -7,8 +7,8 @@ from sklearn.ensemble import IsolationForest, RandomForestClassifier
 from ..abc import Mapper
 from ..ensemble import Ensemble
 from ..feature import Feature
-from ..mip import Model, TreeVar
-from ..typing import Array1D, PositiveInt
+from ..mip import Model, Solution, TreeVar
+from ..typing import Array1D, NonNegativeInt, PositiveInt
 
 
 class MIPExplainer(Model):
@@ -47,10 +47,17 @@ class MIPExplainer(Model):
         )
         self.build()
 
-    def explain(self, x: Array1D, *, norm: PositiveInt) -> Array1D:
+    def explain(
+        self,
+        x: Array1D,
+        *,
+        y: NonNegativeInt,
+        norm: PositiveInt,
+    ) -> Solution:
         self.add_objective(x, norm=norm)
+        self.set_majority_class(y=y)
         self.optimize()
         if self.SolCount == 0:
             msg = "No solution found. Please check the model constraints."
             raise RuntimeError(msg)
-        return self.solution.to_numpy()
+        return self.solution

--- a/ocean/mip/builder/model.py
+++ b/ocean/mip/builder/model.py
@@ -105,7 +105,7 @@ class MIPBuilder(ModelBuilder):
         # tree should go to the left of the node.
         #   :: x <= 1 - flow[node.left],
         #   :: x >= flow[node.right].
-        x = feature.x
+        x = feature.xget()
         model.addConstr(x <= 1 - tree[node.left.node_id])
         model.addConstr(x >= tree[node.right.node_id])
 
@@ -221,7 +221,7 @@ class MIPBuilder(ModelBuilder):
         #   :: x[code] >= 1 - flow[node.left],
         #   :: x[code] >= flow[node.right].
 
-        x = feature[node.code]
+        x = feature.xget(node.code)
         model.addConstr(x <= 1 - tree[node.left.node_id])
         model.addConstr(x >= tree[node.right.node_id])
 

--- a/ocean/mip/model.py
+++ b/ocean/mip/model.py
@@ -163,7 +163,7 @@ class Model(BaseModel):
 
     def vget(self, i: int) -> gp.Var:
         name = self.mapper.names[i]
-        if not self.mapper[name].is_one_hot_encoded:
+        if self.mapper[name].is_one_hot_encoded:
             code = self.mapper.codes[i]
             return self.mapper[name].xget(code)
         return self.mapper[name].xget()

--- a/ocean/mip/solution.py
+++ b/ocean/mip/solution.py
@@ -14,9 +14,9 @@ class Solution(Mapper[FeatureVar]):
             name = self.names[i]
             feature = self[name]
             if not feature.is_one_hot_encoded:
-                return feature.X
+                return feature.xget().X
             code = self.codes[i]
-            return feature[code].X
+            return feature.xget(code).X
 
         values = [get(i) for i in range(self.n_columns)]
         return pd.Series(values, index=self.columns)
@@ -33,18 +33,12 @@ class Solution(Mapper[FeatureVar]):
 
     def __repr__(self) -> str:
         def get(v: FeatureVar) -> float | Key:
-            if not v.is_one_hot_encoded:
-                if v.is_binary:
-                    return int(v.X)
-
-                if np.isclose(v.X, 0.0):
-                    return 0.0
-                return v.X
-            for code in v.codes:
-                if v[code].X == 1:
-                    return code
-            msg = "Unreachable code"
-            raise ValueError(msg)
+            if v.is_one_hot_encoded:
+                for code in v.codes:
+                    if np.isclose(v.xget(code).X, 1.0):
+                        return code
+            x = v.xget().X
+            return 0 if np.isclose(x, 0.0) else x
 
         mapping = self.reduce(get)
         prefix = f"{self.__class__.__name__}:\n"

--- a/ocean/mip/variable/feature.py
+++ b/ocean/mip/variable/feature.py
@@ -53,7 +53,7 @@ class FeatureVar(Var, FeatureKeeper):
     def mget(self, key: int) -> gp.Var:
         if self.is_numeric:
             return self._mu[key].item()
-        msg = "This feature does not support indexing"
+        msg = "The 'mget' method is only supported for numeric features"
         raise ValueError(msg)
 
     def __getitem__(self, code: Key) -> gp.Var:

--- a/tests/explainer/test_mip.py
+++ b/tests/explainer/test_mip.py
@@ -38,7 +38,7 @@ def test_ocean(
     assert model.n_estimators == n_estimators
     assert model.n_classes == n_classes
 
-    model.set_majority_class(m_class=0, output=0)
+    model.set_majority_class(y=0, o=0)
     x = data.iloc[0, :].to_numpy().astype(float).flatten()  # pyright: ignore[reportUnknownVariableType]
     model.add_objective(x, norm=2)  # pyright: ignore[reportArgumentType]
 

--- a/tests/explainer/test_mip.py
+++ b/tests/explainer/test_mip.py
@@ -2,7 +2,7 @@ import gurobipy as gp
 import pytest
 from sklearn.ensemble import RandomForestClassifier
 
-from ocean.explainer import MIPExplainer
+from ocean.explainer import MixedIntegerProgramExplainer
 
 from ..utils import ENV, generate_data
 
@@ -26,11 +26,11 @@ def test_ocean(
         max_depth=max_depth,
     )
     clf.fit(data.to_numpy(), y)
-    model = MIPExplainer(
+    model = MixedIntegerProgramExplainer(
         ensemble=clf,
         mapper=mapper,
         weights=None,
-        model_type=MIPExplainer.Type.MIP,
+        model_type=MixedIntegerProgramExplainer.Type.MIP,
         env=ENV,
     )
 

--- a/tests/explainer/test_mip.py
+++ b/tests/explainer/test_mip.py
@@ -12,7 +12,7 @@ from ..utils import ENV, generate_data
 @pytest.mark.parametrize("max_depth", [2, 3])
 @pytest.mark.parametrize("n_classes", [2, 3, 4])
 @pytest.mark.parametrize("n_samples", [100, 200, 500])
-def test_ocean(
+def test_explain(
     seed: int,
     n_estimators: int,
     max_depth: int,
@@ -25,27 +25,15 @@ def test_ocean(
         n_estimators=n_estimators,
         max_depth=max_depth,
     )
-    clf.fit(data.to_numpy(), y)
-    model = MixedIntegerProgramExplainer(
-        ensemble=clf,
-        mapper=mapper,
-        weights=None,
-        model_type=MixedIntegerProgramExplainer.Type.MIP,
-        env=ENV,
-    )
+    clf.fit(data, y)
+    model = MixedIntegerProgramExplainer(clf, mapper=mapper, env=ENV)
 
-    assert model is not None
-    assert model.n_estimators == n_estimators
-    assert model.n_classes == n_classes
-
-    model.set_majority_class(y=0, o=0)
     x = data.iloc[0, :].to_numpy().astype(float).flatten()  # pyright: ignore[reportUnknownVariableType]
-    model.add_objective(x, norm=2)  # pyright: ignore[reportArgumentType]
 
     try:
+        model.explain(x, y=0, norm=1)
         model.optimize()
         assert model.Status == gp.GRB.OPTIMAL
-        assert model.solution is not None
 
     except gp.GurobiError as e:
         pytest.skip(f"Skipping test due to {e}")

--- a/tests/mip/model/test_feasible.py
+++ b/tests/mip/model/test_feasible.py
@@ -90,7 +90,7 @@ class TestNoIsolation:
 
         n_skipped = 0
         for class_ in classes:
-            model.set_majority_class(m_class=class_)
+            model.set_majority_class(y=class_)
 
             try:
                 model.optimize()
@@ -200,7 +200,7 @@ class TestIsolation:
 
         n_skipped = 0
         for class_ in classes:
-            model.set_majority_class(m_class=class_)
+            model.set_majority_class(y=class_)
 
             try:
                 model.optimize()

--- a/tests/mip/model/test_objective.py
+++ b/tests/mip/model/test_objective.py
@@ -117,7 +117,7 @@ class TestNoIsolation:
 
         n_skipped = 0
         for class_ in classes:
-            model.set_majority_class(m_class=class_)
+            model.set_majority_class(y=class_)
 
             model.add_objective(x=x, norm=norm)
 

--- a/tests/mip/variable/feature/test_optimize.py
+++ b/tests/mip/variable/feature/test_optimize.py
@@ -17,17 +17,18 @@ def test_binary(seed: int) -> None:
     var = FeatureVar(feature=feature, name="x")
     var.build(model)
 
+    v = var.xget()
     val = generator.uniform(0.0, 0.4)
-    objective = (var.x - val) ** 2
+    objective = (v - val) ** 2
     model.setObjective(objective)
     model.optimize()
-    assert var.X == 0.0
+    assert v.X == 0.0
 
     val = generator.uniform(0.6, 1.0)
-    objective = (var.x - val) ** 2
+    objective = (v - val) ** 2
     model.setObjective(objective)
     model.optimize()
-    assert var.X == 1.0
+    assert v.X == 1.0
 
 
 @pytest.mark.parametrize("seed", SEEDS)
@@ -46,17 +47,18 @@ def test_discrete(
     var = FeatureVar(feature=feature, name="x")
     var.build(model)
 
+    v = var.xget()
     val = generator.choice(levels)
-    objective = (var.x - val) ** 2
+    objective = (v - val) ** 2
     model.setObjective(objective)
     model.optimize()
-    assert np.isclose(var.X, val)
+    assert np.isclose(v.X, val)
 
     val = generator.uniform(float(levels.min()), float(levels.max()))
-    objective = (var.x - val) ** 2
+    objective = (v - val) ** 2
     model.setObjective(objective)
     model.optimize()
-    assert np.isclose(var.X, levels[np.abs(levels - val).argmin()])
+    assert np.isclose(v.X, levels[np.abs(levels - val).argmin()])
 
 
 @pytest.mark.parametrize("seed", SEEDS)
@@ -70,27 +72,26 @@ def test_continuous(seed: int, n_levels: int, lower: int, upper: int) -> None:
     var = FeatureVar(feature=feature, name="x")
     var.build(model)
 
-    val = generator.uniform(float(levels.min()), float(levels.max()))
-    objective = (var.x - val) ** 2
+    v = var.xget()
+    lb, ub = np.min(levels), np.max(levels)
+
+    val = generator.uniform(lb, ub)
+    objective = (v - val) ** 2
     model.setObjective(objective)
     model.optimize()
     assert np.isclose(var.X, val)
 
-    val = generator.uniform(
-        float(levels.min()) - 1.0, float(levels.min()) - 0.5
-    )
-    objective = (var.x - val) ** 2
+    val = generator.uniform(lb - 1.0, lb - 0.5)
+    objective = (v - val) ** 2
     model.setObjective(objective)
     model.optimize()
-    assert np.isclose(var.X, levels.min())
+    assert np.isclose(v.X, lb)
 
-    val = generator.uniform(
-        float(levels.max()) + 0.5, float(levels.max()) + 1.0
-    )
-    objective = (var.x - val) ** 2
+    val = generator.uniform(ub + 0.5, ub + 1.0)
+    objective = (v - val) ** 2
     model.setObjective(objective)
     model.optimize()
-    assert np.isclose(var.X, levels.max())
+    assert np.isclose(v.X, ub)
 
 
 @pytest.mark.parametrize("seed", SEEDS)
@@ -104,18 +105,19 @@ def test_one_hot_encoded(seed: int, n_codes: int) -> None:
     var.build(model)
 
     code = generator.choice(codes)
+    v = var.xget(code)
     val = generator.uniform(0.0, 0.4)
-    objective = (var[code] - val) ** 2
+    objective = (v - val) ** 2
     model.setObjective(objective)
     model.optimize()
-    assert var[code].X == 0.0
+    assert v.X == 0.0
 
-    assert sum(1 for code in var.codes if var[code].X == 1.0) == 1
+    assert sum(1 for code in var.codes if var.xget(code).X == 1.0) == 1.0
 
     val = generator.uniform(0.6, 1.0)
-    objective = (var[code] - val) ** 2
+    objective = (v - val) ** 2
     model.setObjective(objective)
     model.optimize()
-    assert var[code].X == 1.0
+    assert v.X == 1.0
 
-    assert sum(1 for code in var.codes if var[code].X == 1.0) == 1
+    assert sum(1 for code in var.codes if var.xget(code).X == 1.0) == 1.0

--- a/tests/mip/variable/feature/test_optimize.py
+++ b/tests/mip/variable/feature/test_optimize.py
@@ -79,7 +79,7 @@ def test_continuous(seed: int, n_levels: int, lower: int, upper: int) -> None:
     objective = (v - val) ** 2
     model.setObjective(objective)
     model.optimize()
-    assert np.isclose(var.X, val)
+    assert np.isclose(v.X, val)
 
     val = generator.uniform(lb - 1.0, lb - 0.5)
     objective = (v - val) ** 2


### PR DESCRIPTION
Improve parameter naming, streamline variable handling, and enhance error messaging across various classes. Update tests for consistency and utilize the new xget method for variable access. Rename MIPExplainer to MixedIntegerProgramExplainer for better clarity.