### PR TITLE
Fix import statement for MixedIntegerProgramExplainer in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ The package provides multiple classes and functions to wrap the tree ensemble mo
 import numpy as np
 from sklearn.ensemble import RandomForestClassifier
 
+from ocean import MixedIntegerProgramExplainer
 from ocean.datasets import load_adult
-from ocean.explainer import MixedIntegerProgramExplainer
 
 # Load the adult dataset
 (data, target), mapper = load_adult()


### PR DESCRIPTION
Correct the import statement for the MixedIntegerProgramExplainer in the README to ensure accurate usage instructions.