### PR TITLE
Refactor parse_features to return DataFrame first

### DIFF
--- a/ocean/datasets/_load.py
+++ b/ocean/datasets/_load.py
@@ -41,7 +41,7 @@ class Loader:
         discretes = tuple(data.columns[types == "D"].to_list())
         encoded = tuple(data.columns[types == "E"].to_list())
         data = data.drop(columns=targets)
-        mapper, data = parse_features(
+        data, mapper = parse_features(
             data,
             discretes=discretes,
             encoded=encoded,

--- a/tests/feature/test_parse.py
+++ b/tests/feature/test_parse.py
@@ -30,7 +30,7 @@ n_features = 5
 
 
 def test_parse() -> None:
-    mapper, data = parse_features(data=DATA)
+    data, mapper = parse_features(data=DATA)
     assert isinstance(mapper, Mapper)
     assert isinstance(data, pd.DataFrame)
     assert data.shape == expected_shape
@@ -50,7 +50,7 @@ def test_parse() -> None:
 
 
 def test_parse_valid() -> None:
-    mapper, data = parse_features(data=DATA, discretes=discretes)
+    data, mapper = parse_features(data=DATA, discretes=discretes)
     assert isinstance(mapper, Mapper)
     assert isinstance(data, pd.DataFrame)
     assert data.shape == (5, 7)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -46,7 +46,7 @@ def generate_data(
         **continuous_values,
         **encoded_values,
     })
-    mapper, data = parse_features(data, discretes=tuple(discrete_values.keys()))
+    data, mapper = parse_features(data, discretes=tuple(discrete_values.keys()))
 
     if n_classes == -1:
         return data, generator.uniform(0, 1, n_samples).flatten(), mapper


### PR DESCRIPTION
Update the `parse_features` function to return the DataFrame before the mapper, improving the clarity of the return values. Adjust related tests to reflect this change.