### PR TITLE
Add ortools to project dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "anytree",
     "gurobipy",
     "numpy",
+    "ortools",
     "pandas",
     "pydantic",
     "scikit-learn",


### PR DESCRIPTION
Include ortools in the project dependencies to enhance optimization capabilities.